### PR TITLE
Mimic `to_s` of wrapper class

### DIFF
--- a/lib/reloader_interceptor/wrapper.rb
+++ b/lib/reloader_interceptor/wrapper.rb
@@ -58,11 +58,14 @@ module ReloaderInterceptor
         Class.new(klass.superclass) do
           extend Wrapper::DSL
 
-          # Define `.name` and `.inspect` to mimic the original class.
+          # Define `.name`, `.inspect`, and `.to_s` to mimic the original class.
           self.define_singleton_method :name do
             klass_name
           end
           self.define_singleton_method :inspect do
+            klass_name
+          end
+          self.define_singleton_method :to_s do
             klass_name
           end
 

--- a/spec/reloader_interceptor/wrapper_spec.rb
+++ b/spec/reloader_interceptor/wrapper_spec.rb
@@ -41,8 +41,10 @@ RSpec.describe ReloaderInterceptor::Wrapper do
       expect(src_class).to receive(:private_singleton_method)
       dst_class.send(:private_singleton_method)
 
-      # Test .name
+      # Test mimicked methods
       expect(dst_class.name).to eq src_class.name
+      expect(dst_class.inspect).to eq src_class.name
+      expect(dst_class.to_s).to eq src_class.name
     end
   end
 end


### PR DESCRIPTION
## Why

Some tracing libraries such as dd-trace use `to_s` to identify the resource. I want to work these libraries for wrapper class as the original class.

Ref (the code of dd-trace to format the gRPC class and its method): https://github.com/DataDog/dd-trace-rb/blob/9fd04441f91f4668c6d31dcff2af2115b38318c0/lib/ddtrace/contrib/grpc/datadog_interceptor/server.rb#L68-L75

## What

Define `to_s` method of wrapper classes to return the original class name.
