### PR TITLE
Add github actions to test ruby 2.7 to 3.1

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,19 @@
+name: Run test
+on: [push]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ruby-version: ['2.7', '3.0', '3.1']
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby-version }}
+          bundler-cache: true
+      - name: Install dependencies
+        run: bundle install
+      - name: Run Rspec
+        run: bundle exec rspec

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,0 @@
----
-language: ruby
-cache: bundler
-rvm:
-  - 2.6.5
-before_install: gem install bundler -v 2.1.4


### PR DESCRIPTION
## Why
- related: https://github.com/wantedly/gcpc/pull/23

## What
- use github actions instead of travis ci
- Run bundle install and test with ruby 2.7 to 3.1

## Check
All Job passed in my forked repo: https://github.com/3150/reloader_interceptor/actions/runs/3836854037